### PR TITLE
Spin up Dannah's staging site on Netlify

### DIFF
--- a/dannahforcitycouncil.tf
+++ b/dannahforcitycouncil.tf
@@ -1,0 +1,15 @@
+module "dannahforcitycouncil-com" {
+  source = "./modules/s3-static-site"
+
+  apex      = "dannahforcitycouncil.com"
+  subdomain = ""
+  name      = "dannahforcitycouncil-com"
+}
+
+module "staging-dannahforcitycouncil-com" {
+  source = "./modules/s3-static-site"
+
+  apex      = "dannahforcitycouncil.com"
+  subdomain = "staging"
+  name      = "staging-dannahforcitycouncil-com"
+}

--- a/dannahforcitycouncil.tf
+++ b/dannahforcitycouncil.tf
@@ -6,10 +6,33 @@ module "dannahforcitycouncil-com" {
   name      = "dannahforcitycouncil-com"
 }
 
-module "staging-dannahforcitycouncil-com" {
-  source = "./modules/s3-static-site"
+resource "netlify_deploy_key" "key" {}
 
-  apex      = "dannahforcitycouncil.com"
-  subdomain = "staging"
-  name      = "staging-dannahforcitycouncil-com"
+# NOTE: See comment in main.tf
+# resource "github_repository_deploy_key" "dannahforcitycouncil-statging" {
+#   key = netlify_deploy_key.key.public_key
+#   read_only = true
+#   repository = "dannah-for-city-council"
+#   title = "Netlify Staging deploy key"
+# }
+
+resource "netlify_site" "dannahforcitycouncil-staging" {
+  custom_domain = "staging.dannahforcitycouncil.com"
+  name = "dannahforcitycouncil-staging"
+
+  repo {
+    repo_branch   = "master"
+    command       = "middleman build -e staging"
+    deploy_key_id = netlify_deploy_key.key.id
+    dir           = "build"
+    provider      = "github"
+    repo_path     = "pbyrne/dannah-for-city-council"
+  }
+}
+
+resource "dnsimple_record" "dannahforcitycouncil-staging" {
+  domain = "dannahforcitycouncil.com"
+  name = "staging"
+  type = "CNAME"
+  value = trimprefix(netlify_site.dannahforcitycouncil-staging.deploy_url, "http://")
 }

--- a/dannahforcitycouncil.tf
+++ b/dannahforcitycouncil.tf
@@ -6,33 +6,13 @@ module "dannahforcitycouncil-com" {
   name      = "dannahforcitycouncil-com"
 }
 
-resource "netlify_deploy_key" "key" {}
+module "staging-dannahforcitycouncil-com" {
+  source = "./modules/netlify-static-site"
 
-# NOTE: See comment in main.tf
-# resource "github_repository_deploy_key" "dannahforcitycouncil-statging" {
-#   key = netlify_deploy_key.key.public_key
-#   read_only = true
-#   repository = "dannah-for-city-council"
-#   title = "Netlify Staging deploy key"
-# }
-
-resource "netlify_site" "dannahforcitycouncil-staging" {
-  custom_domain = "staging.dannahforcitycouncil.com"
-  name = "dannahforcitycouncil-staging"
-
-  repo {
-    repo_branch   = "master"
-    command       = "middleman build -e staging"
-    deploy_key_id = netlify_deploy_key.key.id
-    dir           = "build"
-    provider      = "github"
-    repo_path     = "pbyrne/dannah-for-city-council"
-  }
-}
-
-resource "dnsimple_record" "dannahforcitycouncil-staging" {
-  domain = "dannahforcitycouncil.com"
-  name = "staging"
-  type = "CNAME"
-  value = trimprefix(netlify_site.dannahforcitycouncil-staging.deploy_url, "http://")
+  apex = "dannahforcitycouncil.com"
+  subdomain = "staging"
+  name = "staging-dannahforcitycouncil-com"
+  command = "middleman build -e staging"
+  repo = "pbyrne/dannah-for-city-council"
+  deploy_key = netlify_deploy_key.key
 }

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,12 @@ provider "dnsimple" {
 provider "netlify" {
 }
 
+# TODO Use this to generate deploy keys automatically on GitHub once this is closed
+# https://github.com/terraform-providers/terraform-provider-github/issues/371
+# provider "github" {
+#   individual = true
+# }
+
 terraform {
   backend "s3" {
     bucket = "patrick-byrne-terraform-state"

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,9 @@ provider "aws" {
 provider "dnsimple" {
 }
 
+provider "netlify" {
+}
+
 terraform {
   backend "s3" {
     bucket = "patrick-byrne-terraform-state"

--- a/modules/netlify-static-site/main.tf
+++ b/modules/netlify-static-site/main.tf
@@ -1,0 +1,28 @@
+# NOTE: See comment in main.tf
+# resource "github_repository_deploy_key" "itself" {
+#   key = netlify_deploy_key.key.public_key
+#   read_only = true
+#   repository = "repo"
+#   title = "Netlify Staging deploy key"
+# }
+
+resource "netlify_site" "itself" {
+  custom_domain = local.domain
+  name = var.name
+
+  repo {
+    repo_branch   = "master"
+    command       = var.command
+    deploy_key_id = var.deploy_key.id
+    dir           = "build"
+    provider      = "github"
+    repo_path     = var.repo
+  }
+}
+
+resource "dnsimple_record" "itself" {
+  domain = var.apex
+  name   = var.subdomain
+  type   = local.subdomain_type
+  value  = trimprefix(netlify_site.itself.deploy_url, "http://")
+}

--- a/modules/netlify-static-site/vars.tf
+++ b/modules/netlify-static-site/vars.tf
@@ -1,0 +1,32 @@
+variable "apex" {
+  default = "example.com"
+  description = "Apex domain of the site"
+}
+
+variable "subdomain" {
+  default = ""
+  description = "Subdomain, if any, of the site"
+}
+
+variable "name" {
+  description = "Unique name to refer to the resources"
+}
+
+variable "command" {
+  default = "middleman build"
+  description = "Command to build the site"
+}
+
+variable "repo" {
+  description = "GitHub repo path for the site"
+}
+
+variable "deploy_key" {
+  description = "Netlify deploy key resource"
+}
+
+locals {
+  domain_pieces  = [var.subdomain, var.apex]
+  domain         = join(".", compact(local.domain_pieces))
+  subdomain_type = var.subdomain == "" ? "ALIAS" : "CNAME"
+}

--- a/modules/s3-static-site/vars.tf
+++ b/modules/s3-static-site/vars.tf
@@ -27,4 +27,3 @@ locals {
   domain         = join(".", compact(local.domain_pieces))
   subdomain_type = var.subdomain == "" ? "ALIAS" : "CNAME"
 }
-

--- a/netlify.tf
+++ b/netlify.tf
@@ -1,0 +1,1 @@
+resource "netlify_deploy_key" "key" {}

--- a/s3-static-sites.tf
+++ b/s3-static-sites.tf
@@ -30,18 +30,3 @@ module "somefine-tv" {
   name      = "somefine-tv"
 }
 
-module "dannahforcitycouncil-com" {
-  source = "./modules/s3-static-site"
-
-  apex      = "dannahforcitycouncil.com"
-  subdomain = ""
-  name      = "dannahforcitycouncil-com"
-}
-
-module "staging-dannahforcitycouncil-com" {
-  source = "./modules/s3-static-site"
-
-  apex      = "dannahforcitycouncil.com"
-  subdomain = "staging"
-  name      = "staging-dannahforcitycouncil-com"
-}


### PR DESCRIPTION
Because:

* I want some of the automation (like triggering builds from Zapier)
  that Netlify provides. Plus it gets me off Amazon.

Solution:

* Spin down DFCC staging site on AWS
* Spin up same on Netlify