### PR TITLE
Point at new providers in versions file

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,12 +8,6 @@ provider "dnsimple" {
 provider "netlify" {
 }
 
-# TODO Use this to generate deploy keys automatically on GitHub once this is closed
-# https://github.com/terraform-providers/terraform-provider-github/issues/371
-# provider "github" {
-#   individual = true
-# }
-
 terraform {
   backend "remote" {
     hostname = "app.terraform.io"

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ provider "netlify" {
 
 terraform {
   backend "remote" {
-    hostname = "app.terraform.io"
+    hostname     = "app.terraform.io"
     organization = "byrnefamily"
 
     workspaces {

--- a/modules/fastmail-mx/versions.tf
+++ b/modules/fastmail-mx/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     dnsimple = {
-      source = "terraform-providers/dnsimple"
+      source = "dnsimple/dnsimple"
     }
   }
 }

--- a/modules/netlify-dns-record/versions.tf
+++ b/modules/netlify-dns-record/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     dnsimple = {
-      source = "terraform-providers/dnsimple"
+      source = "dnsimple/dnsimple"
     }
   }
   required_version = ">= 0.13"

--- a/modules/netlify-static-site/versions.tf
+++ b/modules/netlify-static-site/versions.tf
@@ -1,10 +1,10 @@
 terraform {
   required_providers {
     dnsimple = {
-      source = "terraform-providers/dnsimple"
+      source = "dnsimple/dnsimple"
     }
     netlify = {
-      source = "terraform-providers/netlify"
+      source = "royge/netlify"
     }
   }
   required_version = ">= 0.13"

--- a/modules/s3-static-site/versions.tf
+++ b/modules/s3-static-site/versions.tf
@@ -6,7 +6,7 @@ terraform {
       source = "hashicorp/aws"
     }
     dnsimple = {
-      source = "terraform-providers/dnsimple"
+      source = "dnsimple/dnsimple"
     }
   }
 }

--- a/somefine.tv.tf
+++ b/somefine.tv.tf
@@ -1,7 +1,7 @@
 module "netlify-somefine-tv-record" {
   source = "./modules/netlify-dns-record"
 
-  apex = "somefine.tv"
+  apex      = "somefine.tv"
   subdomain = ""
-  name = "somefine-tv"
+  name      = "somefine-tv"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -5,7 +5,7 @@ terraform {
       source = "hashicorp/aws"
     }
     digitalocean = {
-      source = "digitalocean/digitalocean"
+      source  = "digitalocean/digitalocean"
       version = "~> 2.0"
     }
     dnsimple = {

--- a/versions.tf
+++ b/versions.tf
@@ -1,15 +1,18 @@
-
 terraform {
   required_version = ">= 0.13"
   required_providers {
     aws = {
       source = "hashicorp/aws"
     }
+    digitalocean = {
+      source = "digitalocean/digitalocean"
+      version = "~> 2.0"
+    }
     dnsimple = {
-      source = "terraform-providers/dnsimple"
+      source = "dnsimple/dnsimple"
     }
     netlify = {
-      source = "terraform-providers/netlify"
+      source = "royge/netlify"
     }
   }
 }


### PR DESCRIPTION
Because:

* Legacy providers are deprecated
* The legacy Netlify provider doesn't have an ARM64 version available,
  so I have to choose a forked version
* Some of the legacy providers have been claimed by their owners and are
  being officially maintained

Solution:

* Point at the new providers everywhere
